### PR TITLE
ItemStack comparator modes

### DIFF
--- a/src/main/java/be/elmital/highlightItem/Configurator.java
+++ b/src/main/java/be/elmital/highlightItem/Configurator.java
@@ -37,6 +37,7 @@ public class Configurator {
     private final Path currentDirectory;
     public static HighlightItem.HighLightColor HIGHLIGHT_COLOR;
     public static boolean COLOR_HOVERED;
+    public static ItemComparator.Comparators COMPARATOR;
     private final String CONFIG = "HighLightItemConfig";
     private final Properties properties = new Properties();
 
@@ -52,7 +53,8 @@ public class Configurator {
     public enum Config {
         COLOR("highlight-color", HighlightItem.HighLightColor.DEFAULT.name()),
         COLOR_HOVERED("color-hovered", "false"),
-        TOGGLE("toggle", "true");
+        TOGGLE("toggle", "true"),
+        COMPARATOR("comparator", ItemComparator.Comparators.ITEM_ONLY.name());
 
         private final String key;
         private final String def;
@@ -86,6 +88,7 @@ public class Configurator {
         TOGGLE = Boolean.parseBoolean(properties.getProperty(Config.TOGGLE.getKey(), Config.TOGGLE.getDefault()));
         HIGHLIGHT_COLOR = HighlightItem.HighLightColor.valueOf(properties.getProperty(COLOR.getKey(), COLOR.getDefault()));
         COLOR_HOVERED = Boolean.parseBoolean(properties.getProperty(Config.COLOR_HOVERED.getKey(), Config.COLOR_HOVERED.getDefault()));
+        COMPARATOR = ItemComparator.Comparators.valueOf(properties.getProperty(Config.COMPARATOR.getKey(), Config.COMPARATOR.getDefault()));
     }
 
     public Path getConfigDirectoryPath() {

--- a/src/main/java/be/elmital/highlightItem/HighLightCommands.java
+++ b/src/main/java/be/elmital/highlightItem/HighLightCommands.java
@@ -78,11 +78,24 @@ public class HighLightCommands {
                         context.getSource().getPlayer().sendMessage(Text.of("The config file can't be updated!"));
                     }
                     return Command.SINGLE_SUCCESS;
-                }))
+                })).then(literal("mode")
+                        .then(argument("mode", ItemComparator.ComparatorArgumentType.comparator())
+                                .executes(context -> {
+                                    var mode = ItemComparator.ComparatorArgumentType.getComparator("mode", context);
+                                    Configurator.COMPARATOR = mode;
+                                    try {
+                                        HighlightItem.configurator.updateConfig(Configurator.Config.COMPARATOR, mode.name());
+                                        context.getSource().getPlayer().sendMessage(Text.of("Mode changed!"));
+                                    } catch (IOException e) {
+                                        context.getSource().getPlayer().sendMessage(Text.of("The config file can't be updated!"));
+                                    }
+                                    return Command.SINGLE_SUCCESS;
+                                })))
         ));
     }
 
     public void registerArgumentTypes() {
         ArgumentTypeRegistry.registerArgumentType(new Identifier("highlightitem:color"), HighLightColorArgumentType.class, ConstantArgumentSerializer.of(HighLightColorArgumentType::color));
+        ArgumentTypeRegistry.registerArgumentType(new Identifier("highlightitem:mode"), ItemComparator.ComparatorArgumentType.class, ConstantArgumentSerializer.of(ItemComparator.ComparatorArgumentType::comparator));
     }
 }

--- a/src/main/java/be/elmital/highlightItem/ItemComparator.java
+++ b/src/main/java/be/elmital/highlightItem/ItemComparator.java
@@ -1,0 +1,83 @@
+package be.elmital.highlightItem;
+
+import com.mojang.brigadier.StringReader;
+import com.mojang.brigadier.arguments.ArgumentType;
+import com.mojang.brigadier.context.CommandContext;
+import com.mojang.brigadier.exceptions.CommandSyntaxException;
+import com.mojang.brigadier.exceptions.SimpleCommandExceptionType;
+import com.mojang.brigadier.suggestion.Suggestions;
+import com.mojang.brigadier.suggestion.SuggestionsBuilder;
+import net.minecraft.command.CommandSource;
+import net.minecraft.item.ItemStack;
+import net.minecraft.text.Text;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.concurrent.CompletableFuture;
+import java.util.function.BiPredicate;
+
+public class ItemComparator {
+    public static final BiPredicate<ItemStack, ItemStack> itemOnlyPredicate = (stack, stack2) -> stack.getItem().equals(stack2.getItem());
+    public static final BiPredicate<ItemStack, ItemStack> itemAndAmountPredicate = ((BiPredicate<ItemStack, ItemStack>) (stack, stack2) -> stack.getCount() == stack2.getCount()).and(itemOnlyPredicate);
+    public static final BiPredicate<ItemStack, ItemStack> itemAndNBTPredicate = itemOnlyPredicate.and((stack, stack2) -> (stack.getNbt() == null && stack2.getNbt() == null) || (stack.getNbt() != null && stack2.getNbt() != null && stack.getNbt().equals(stack2.getNbt())));
+    public static final BiPredicate<ItemStack, ItemStack> equalsPredicate = itemAndAmountPredicate.and((stack, stack2) -> (stack.getNbt() == null && stack2.getNbt() == null) || (stack.getNbt() != null && stack2.getNbt() != null && stack.getNbt().equals(stack2.getNbt())));
+
+    public static boolean test(Comparators comparator, ItemStack stack, ItemStack stack2) {
+        return switch (comparator) {
+            case ITEM_ONLY -> itemOnlyPredicate.test(stack, stack2);
+            case ITEM_AND_AMOUNT -> itemAndAmountPredicate.test(stack, stack2);
+            case ITEM_AND_NBT -> itemAndNBTPredicate.test(stack, stack2);
+            case ITEM_AND_NBT_AND_AMOUNT -> equalsPredicate.test(stack, stack2);
+        };
+    }
+
+    public static class ComparatorArgumentType implements ArgumentType<Comparators> {
+        private static final Collection<String> EXAMPLES = generateExamples();
+
+        public static ComparatorArgumentType comparator() {
+            return new ComparatorArgumentType();
+        }
+
+        public static <S> Comparators getComparator(String name, CommandContext<S> context) {
+            return context.getArgument(name, Comparators.class);
+        }
+
+        @Override
+        public Comparators parse(StringReader reader) throws CommandSyntaxException {
+            int areBeginning = reader.getCursor();
+            if(!reader.canRead())
+                reader.skip();
+
+            while (reader.canRead() && reader.peek() != ' ')
+                reader.skip();
+
+            String mode = reader.getString().substring(areBeginning, reader.getCursor());
+            try {
+                return Comparators.valueOf(mode.toUpperCase());
+            } catch (IllegalArgumentException iae) {
+                throw new SimpleCommandExceptionType(Text.of(iae.getMessage())).createWithContext(reader);
+            }
+        }
+
+        @Override
+        public Collection<String> getExamples() {
+            return EXAMPLES;
+        }
+
+        private static Collection<String> generateExamples() {
+            return Arrays.stream(Comparators.values()).map(comparator -> comparator.name().toLowerCase()).toList();
+        }
+
+        @Override
+        public <S> CompletableFuture<Suggestions> listSuggestions(CommandContext<S> context, SuggestionsBuilder builder) {
+            return CommandSource.suggestMatching(EXAMPLES, builder);
+        }
+    }
+
+    public enum Comparators {
+        ITEM_ONLY,
+        ITEM_AND_AMOUNT,
+        ITEM_AND_NBT,
+        ITEM_AND_NBT_AND_AMOUNT
+    }
+}

--- a/src/main/java/be/elmital/highlightItem/mixin/HandledScreenMixin.java
+++ b/src/main/java/be/elmital/highlightItem/mixin/HandledScreenMixin.java
@@ -23,6 +23,7 @@
 package be.elmital.highlightItem.mixin;
 
 import be.elmital.highlightItem.Configurator;
+import be.elmital.highlightItem.ItemComparator;
 import com.mojang.blaze3d.systems.RenderSystem;
 import net.fabricmc.api.EnvType;
 import net.fabricmc.api.Environment;
@@ -62,7 +63,7 @@ public class HandledScreenMixin {
 					if (focusedSlot.equals(slot) && !Configurator.COLOR_HOVERED)
 						continue;
 
-					if (slot.isEnabled() && !slot.getStack().isEmpty() && slot.getStack().getItem().equals(focusedSlot.getStack().getItem())) {
+					if (slot.isEnabled() && !slot.getStack().isEmpty() && ItemComparator.test(Configurator.COMPARATOR, focusedSlot.getStack(), slot.getStack())) {
 						var activeHighLightColor = Configurator.HIGHLIGHT_COLOR.getShaderColor();
 						RenderSystem.setShaderColor(activeHighLightColor[0], activeHighLightColor[1], activeHighLightColor[2], activeHighLightColor[3]);
 						drawSlotHighlight(context, slot.x, slot.y, 0);


### PR DESCRIPTION
Add new modes to compare ItemStack now the user will have the choice beetween :

- ITEM_ONLY : This mode will only compare if the items are identicals for example if it's a oak door or not. It's how the mod has compare ItemStack until today and is the default mode
- ITEM_AND_AMOUNT : Like the previous mode but it will compare if stacks has the same amount for example only all the 2 oak doors stacks will be highlighted
- ITEM_AND_NBT : It will compare like ITEM_ONLY mode plus compare the NBT for example does a name tag uses same names or shulker boxes contains the same exact content
- ITEM_AND_NBT_AND_AMOUNT : It's a mix of all previous modes


This PR is planed to be merged after the update to MC 1.20.2 #13 