### PR TITLE
Fix mods incompatibility issues

### DIFF
--- a/src/main/java/be/elmital/highlightItem/ConfigurationScreen.java
+++ b/src/main/java/be/elmital/highlightItem/ConfigurationScreen.java
@@ -45,10 +45,10 @@ public class ConfigurationScreen extends GameOptionsScreen {
 
     public ConfigurationScreen(GameOptions gameOptions) {
         super(null, gameOptions, Text.literal("HighLightItem"));
-        this.red = (int) (Configurator.COLOR[0] * 255);
-        this.green = (int) (Configurator.COLOR[1] * 255);
-        this.blue = (int) (Configurator.COLOR[2] * 255);
-        this.alpha = Configurator.COLOR[3] * 100;
+        this.red = ColorHelper.Argb.getRed(Configurator.COLOR);
+        this.green = ColorHelper.Argb.getGreen(Configurator.COLOR);
+        this.blue = ColorHelper.Argb.getBlue(Configurator.COLOR);
+        this.alpha = (ColorHelper.Argb.getAlpha(Configurator.COLOR) / 255f) * 100;
     }
 
     @Override

--- a/src/main/java/be/elmital/highlightItem/HighLightCommands.java
+++ b/src/main/java/be/elmital/highlightItem/HighLightCommands.java
@@ -31,6 +31,7 @@ import net.fabricmc.fabric.api.command.v2.ArgumentTypeRegistry;
 import net.minecraft.command.argument.serialize.ConstantArgumentSerializer;
 import net.minecraft.text.Text;
 import net.minecraft.util.Identifier;
+import net.minecraft.util.math.ColorHelper;
 
 import java.io.IOException;
 
@@ -61,7 +62,9 @@ public class HighLightCommands {
                         .then(argument("color", Colors.HighLightColorArgumentType.color())
                                 .executes(context -> {
                                     var color = Colors.HighLightColorArgumentType.getColor("color", context);
-                                    Configurator.COLOR = color.getShaderColor();
+                                    var colors = color.getShaderColor();
+
+                                    Configurator.COLOR = ColorHelper.Argb.getArgb((int) (colors[3] * 255), (int) (colors[0] * 255), (int) (colors[1] * 255), (int) (colors[2] * 255));
                                     try {
                                         HighlightItem.configurator.updateConfig(Configurator.Config.COLOR, color.json().toString());
                                         context.getSource().getPlayer().sendMessage(Text.of("Color changed!"));

--- a/src/main/java/be/elmital/highlightItem/mixin/HandledScreenMixin.java
+++ b/src/main/java/be/elmital/highlightItem/mixin/HandledScreenMixin.java
@@ -31,7 +31,6 @@ import net.fabricmc.api.Environment;
 import net.minecraft.client.gui.DrawContext;
 import net.minecraft.client.gui.screen.ingame.HandledScreen;
 import net.minecraft.screen.slot.Slot;
-import net.minecraft.util.math.ColorHelper;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.Unique;
@@ -85,9 +84,8 @@ public abstract class HandledScreenMixin {
 	@ModifyArgs(method = "drawSlotHighlight", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/gui/DrawContext;fillGradient(Lnet/minecraft/client/render/RenderLayer;IIIIIII)V"))
 	private static void modifyColor(Args args) {
 		if (MOD_HIGHLIGHT_CALL) {
-			int color = ColorHelper.Argb.getArgb((int) (Configurator.COLOR[3] * 255.0F), (int) (Configurator.COLOR[0] * 255.0F), (int) (Configurator.COLOR[1] * 255.0F), (int) (Configurator.COLOR[2] * 255.0F));
-			args.set(5, color);
-			args.set(6, color);
+			args.set(5, Configurator.COLOR);
+			args.set(6, Configurator.COLOR);
 			MOD_HIGHLIGHT_CALL = false;
 		}
 	}

--- a/src/main/java/be/elmital/highlightItem/mixin/HandledScreenMixin.java
+++ b/src/main/java/be/elmital/highlightItem/mixin/HandledScreenMixin.java
@@ -25,66 +25,74 @@ package be.elmital.highlightItem.mixin;
 import be.elmital.highlightItem.Configurator;
 import be.elmital.highlightItem.HighlightItem;
 import be.elmital.highlightItem.ItemComparator;
+import com.llamalad7.mixinextras.sugar.Local;
 import net.fabricmc.api.EnvType;
 import net.fabricmc.api.Environment;
 import net.minecraft.client.gui.DrawContext;
 import net.minecraft.client.gui.screen.ingame.HandledScreen;
-import net.minecraft.client.render.RenderLayer;
-import net.minecraft.client.render.VertexConsumer;
-import net.minecraft.screen.ScreenHandler;
 import net.minecraft.screen.slot.Slot;
-import org.joml.Matrix4f;
+import net.minecraft.util.math.ColorHelper;
 import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.ModifyArgs;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+import org.spongepowered.asm.mixin.injection.invoke.arg.Args;
 
 
 @Environment(EnvType.CLIENT)
 @Mixin(HandledScreen.class)
-public class HandledScreenMixin {
+public abstract class HandledScreenMixin {
+	@Shadow protected abstract boolean isPointOverSlot(Slot slot, double pointX, double pointY);
 
-	@Inject(
-			method = "render",
-			at = @At(
-					value = "INVOKE",
-					target = "Lnet/minecraft/client/gui/screen/ingame/HandledScreen;drawForeground(Lnet/minecraft/client/gui/DrawContext;II)V"
-			)
-	)
-	private void render(DrawContext context, int mouseX, int mouseY, float delta, CallbackInfo info) {
+	@Unique
+	private static Slot FOCUSED = null;
+	@Unique
+	private static boolean MOD_HIGHLIGHT_CALL = false;
+
+	@Inject(method = "render", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/gui/screen/ingame/HandledScreen;drawSlot(Lnet/minecraft/client/gui/DrawContext;Lnet/minecraft/screen/slot/Slot;)V", shift = At.Shift.AFTER))
+	private void renderInLoop(DrawContext context, int mouseX, int mouseY, float delta, CallbackInfo ci, @Local Slot slot) {
 		if (Configurator.TOGGLE) {
-			Slot focusedSlot = ((HandledScreenAccessor) this).getFocusedSlot();
-
-			if (focusedSlot != null && focusedSlot.getStack() != null) {
-				ScreenHandler handler = ((HandledScreenAccessor) this).getHandler();
-
-				for (int k = 0; k < handler.slots.size(); ++k) {
-					Slot slot = handler.slots.get(k);
-
-					if (focusedSlot.equals(slot) && !Configurator.COLOR_HOVERED)
-						continue;
-
-					if (slot.isEnabled() && !slot.getStack().isEmpty() && ItemComparator.test(Configurator.COMPARATOR, focusedSlot.getStack(), slot.getStack())) {
-						Matrix4f matrix4f = context.getMatrices().peek().getPositionMatrix();
-						VertexConsumer vertexConsumer = context.getVertexConsumers().getBuffer(RenderLayer.getGuiOverlay());
-						vertexConsumer.vertex(matrix4f, (float)slot.x, (float)slot.y, (float)0).color(Configurator.COLOR[0], Configurator.COLOR[1], Configurator.COLOR[2], Configurator.COLOR[3]);
-						vertexConsumer.vertex(matrix4f, (float)slot.x, (float)slot.y + 16, (float)0).color(Configurator.COLOR[0], Configurator.COLOR[1], Configurator.COLOR[2], Configurator.COLOR[3]);
-						vertexConsumer.vertex(matrix4f, (float)slot.x + 16, (float)slot.y + 16, (float)0).color(Configurator.COLOR[0], Configurator.COLOR[1], Configurator.COLOR[2], Configurator.COLOR[3]);
-						vertexConsumer.vertex(matrix4f, (float)slot.x + 16, (float)slot.y, (float)0).color(Configurator.COLOR[0], Configurator.COLOR[1], Configurator.COLOR[2], Configurator.COLOR[3]);
-						context.draw();
+			if (FOCUSED == null) {
+				for (Slot slot1 : ((HandledScreenAccessor) this).getHandler().slots) {
+					if (this.isPointOverSlot(slot1, mouseX, mouseY)) {
+						FOCUSED = slot1;
+						break;
 					}
 				}
+			}
+
+			if (FOCUSED == null || (FOCUSED.equals(slot) && !Configurator.COLOR_HOVERED))
+				return;
+
+			if (slot.isEnabled() && !slot.getStack().isEmpty() && ItemComparator.test(Configurator.COMPARATOR, FOCUSED.getStack(), slot.getStack())) {
+				MOD_HIGHLIGHT_CALL = true;
+				HandledScreen.drawSlotHighlight(context, slot.x, slot.y, 0);
 			}
 		}
 		if (Configurator.notificationTicks > 0 && Configurator.notification != null)
 			context.drawCenteredTextWithShadow(HighlightItem.CLIENT.textRenderer, Configurator.notification, ((HandledScreenAccessor) this).getBackgroundWidth() / 2, ((HandledScreenAccessor) this).getBackgroundHeight() + 2, 0);
 	}
 
-	@Inject(
-			method = "keyPressed(III)Z",
-			at = @At("RETURN")
-	)
+	@Inject(method = "render", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/gui/screen/ingame/HandledScreen;drawForeground(Lnet/minecraft/client/gui/DrawContext;II)V"))
+	private void renderAfterLoop(DrawContext context, int mouseX, int mouseY, float delta, CallbackInfo ci) {
+		FOCUSED = null;
+	}
+
+	@ModifyArgs(method = "drawSlotHighlight", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/gui/DrawContext;fillGradient(Lnet/minecraft/client/render/RenderLayer;IIIIIII)V"))
+	private static void modifyColor(Args args) {
+		if (MOD_HIGHLIGHT_CALL) {
+			int color = ColorHelper.Argb.getArgb((int) (Configurator.COLOR[3] * 255.0F), (int) (Configurator.COLOR[0] * 255.0F), (int) (Configurator.COLOR[1] * 255.0F), (int) (Configurator.COLOR[2] * 255.0F));
+			args.set(5, color);
+			args.set(6, color);
+			MOD_HIGHLIGHT_CALL = false;
+		}
+	}
+
+	@Inject(method = "keyPressed(III)Z", at = @At("RETURN"))
 	private boolean keyPressed(int keyCode, int scanCode, int modifiers, CallbackInfoReturnable<Boolean> info) {
 		assert HighlightItem.CLIENT.player != null;
 		if (Configurator.TOGGLE_BIND.matchesKey(keyCode, scanCode)) {


### PR DESCRIPTION
Should fixes #22 and future others issues with mods touching at the same stuff than HighLightItem

No plan to backport that patch if it works. Should not be merged until #21 is merged.
The fix hasn't be tested with the mod  [Minecraft-Smooth-Scrolling](https://github.com/SmajloSlovakian/Minecraft-Smooth-Scrolling) because I haven't found a MC 1.21 compatible artifact to test even if based on the analyse of the code this should works now.

Waiting for the developer for an MC 1.21 version of the mod to test or feedback if he tests it on his side.

- [x] Test with Minecraft-Smooth-Scrolling 
- [x] Change how the color is stored in the Configurator to remove redundant operations